### PR TITLE
docs(bicep): document v2.0.0 release in mkdocs site

### DIFF
--- a/docs/bicep/how-to-deploy.md
+++ b/docs/bicep/how-to-deploy.md
@@ -13,14 +13,15 @@ Choose your preferred deployment mode based on project requirements and environm
 
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
+- [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) — required by the pre-flight validation hook (v2.0.0+)
 - [Git](https://git-scm.com/downloads)
 
 !!! note
-    Azure CLI is included as a prerequisite for future pre/post provisioning hooks that may depend on it.
+    Azure CLI and PowerShell 7+ are required by the `azd preprovision` hook that runs `scripts/Invoke-PreflightChecks.ps1` before deployment. You can bypass the hook by setting `PREFLIGHT_SKIP=true` in your shell, but the script is the fastest way to catch parameter mistakes (subnet sizing, CIDR overlap, BYO resource typos) before they reach ARM.
 
 ## Basic Deployment
 
-Quick setup for demos and development environments without network isolation.
+Quick setup for demos and development environments without network isolation. This is the **standalone** topology (the default in v2.0.0).
 
 **1. Initialize the project**
 
@@ -49,7 +50,7 @@ azd provision
 
 ## Zero Trust Deployment
 
-For deployments that **require network isolation**. All services communicate through private endpoints and public access is disabled.
+For deployments that **require network isolation**. All services communicate through private endpoints and public access is disabled (unless you supplement with an `allowedIpRanges` list, see below).
 
 **1. Initialize the project**
 
@@ -96,7 +97,46 @@ After a Zero Trust deployment, use the Jumpbox VM to access services inside the 
    - In the Azure Portal, go to your VM resource → **Connect** → **Bastion**
    - Enter the credentials you set in step 1
 
-## Next steps
+## AI Landing Zone Integrated Deployment
 
+For deployments that **plug into an existing Azure Landing Zone** — i.e. the spoke peers to a corporate hub that already provides Bastion, Firewall, Private DNS zones, and Log Analytics.
+
+This topology assumes you (or another team) already operate a hub VNet and shared platform services. The AI Landing Zone spoke consumes them rather than re-creating them.
+
+**1. Initialize the project**
+
+```bash
+azd init -t azure/bicep-ptn-aiml-landing-zone
+```
+
+**2. Set the topology preset and hub integration**
+
+```bash
+azd env set DEPLOYMENT_MODE ailz-integrated
+azd env set HUB_VNET_RESOURCE_ID "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<hub-vnet>"
+azd env set EGRESS_NEXT_HOP_IP "<hub firewall private IP>"
+```
+
+You'll typically also bring your own observability and DNS zones:
+
+```bash
+azd env set EXISTING_LOG_ANALYTICS_WORKSPACE_ID "/subscriptions/.../workspaces/<law>"
+azd env set EXISTING_APPLICATION_INSIGHTS_ID    "/subscriptions/.../components/<ai>"
+# Plus per-zone EXISTING_PRIVATE_DNS_ZONE_* IDs as needed — see Parameterization
+```
+
+**3. Sign in and provision**
+
+```bash
+az login
+azd auth login
+azd provision
+```
+
+!!! info "Full walkthrough"
+    The [Hub-and-Spoke Topology](hub-and-spoke.md) page documents this scenario end-to-end, including a minimal test hub Bicep template, IP planning, peering setup, and verifying connectivity through the hub Bastion.
+
+## Next steps
+- [Migration to v2.0](migration-v2.md) — Upgrade guide for users coming from v1.x
 - [Parameterization](parameterization.md) — Customize your deployment
 - [Permissions](permissions.md) — Understand the role assignments

--- a/docs/bicep/hub-and-spoke.md
+++ b/docs/bicep/hub-and-spoke.md
@@ -1,0 +1,87 @@
+# Hub-and-Spoke Topology
+
+This page summarizes the **hub-and-spoke** deployment topology introduced in **v2.0.0**: the AI Landing Zone spoke peers to a hub VNet that hosts shared platform services (Azure Firewall, Bastion, Private DNS zones, Log Analytics workspace).
+
+For the full end-to-end walkthrough — including the minimal test hub Bicep template, IP planning, peering setup, post-provisioning steps from the jumpbox, and the verification checklist — read the source runbook at [docs/runbook-hub-spoke.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md).
+
+## When to use this topology
+
+Pick hub-and-spoke when **any** of the following applies:
+
+- A platform team already operates a corporate hub VNet (Connectivity subscription) with Azure Firewall and a central Bastion.
+- DNS, identity, monitoring, or networking policy is centrally managed by a different team than the one shipping the AI workload.
+- Multiple AI workloads (or other workloads) need to share egress, jumpbox, and DNS resolution.
+- You are integrating the AI Landing Zone into an [Azure Landing Zone](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/) (CAF).
+
+## What the spoke creates vs. consumes
+
+| Resource | Spoke creates | Consumes from hub |
+|---|---|---|
+| Spoke VNet, subnets, NSGs | ✅ | — |
+| Private endpoints for AI services | ✅ | — |
+| AI Foundry, AI Search, Cosmos DB, Storage, ACR, App Config, Key Vault | ✅ | — |
+| Container Apps environment + workload profiles | ✅ | — |
+| Log Analytics workspace | Optional | ✅ via `existingPlatformServices.logAnalyticsWorkspaceResourceId` |
+| Application Insights | Optional | ✅ via `existingPlatformServices.applicationInsightsResourceId` |
+| Private DNS zones (15 namespaces) | Optional, per-zone | ✅ via `existingPrivateDnsZones.*` |
+| Azure Firewall | Optional | ✅ via `hubIntegration.egressNextHopIp` |
+| Bastion | Optional | ✅ (hub Bastion reaches spoke jumpbox via peering) |
+| Jumpbox VM | Optional | ✅ via `existingJumpboxResourceId` |
+| NAT Gateway | Optional | — (typically the hub firewall provides egress) |
+| Spoke→hub VNet peering | ✅ (created by `main.bicep`) | — |
+
+## Minimum parameters
+
+For an AI LZ Integrated deployment:
+
+```bash
+azd env set DEPLOYMENT_MODE                  ailz-integrated
+azd env set HUB_VNET_RESOURCE_ID             "/subscriptions/<sub>/resourceGroups/<hub-rg>/providers/Microsoft.Network/virtualNetworks/<hub-vnet>"
+azd env set EGRESS_NEXT_HOP_IP               "<hub firewall private IP>"
+azd env set NETWORK_ISOLATION                true
+
+# Recommended: reuse hub observability
+azd env set EXISTING_LOG_ANALYTICS_WORKSPACE_ID "/subscriptions/.../workspaces/<law>"
+azd env set EXISTING_APPLICATION_INSIGHTS_ID    "/subscriptions/.../components/<ai>"
+```
+
+If your hub also hosts the standard Private DNS zones, set each `EXISTING_PRIVATE_DNS_ZONE_*` variable to its hub resource ID. See [Parameterization](parameterization.md) for the complete list of 15 zone parameters.
+
+## Network planning
+
+The spoke VNet address space must not overlap with the hub VNet. The default spoke prefix (`10.0.0.0/22`) is safe for a hub on `10.100.0.0/16`. If your hub uses a different prefix, set:
+
+```bash
+azd env set VNET_ADDRESS_PREFIXES "[\"10.200.0.0/22\"]"
+```
+
+Subnet minimums enforced by the pre-flight script:
+
+| Subnet | Minimum size | Notes |
+|---|---|---|
+| Container Apps environment | `/27` (consumption), `/23` (workload profiles) | AVM requirement |
+| Private endpoints | `/28` | One IP per private endpoint |
+| AzureBastionSubnet | `/26` | Fixed by Bastion |
+| AzureFirewallSubnet | `/26` | Fixed by Azure Firewall |
+| Jumpbox | `/29` | One IP per VM |
+
+## Deployment flow
+
+```mermaid
+flowchart LR
+    A[Hub team:<br/>VNet + Firewall + Bastion<br/>+ Private DNS zones<br/>+ LAW] --> B
+    B[You: set DEPLOYMENT_MODE=ailz-integrated<br/>+ HUB_VNET_RESOURCE_ID<br/>+ EGRESS_NEXT_HOP_IP] --> C
+    C[azd preprovision:<br/>Invoke-PreflightChecks.ps1] --> D
+    D[azd provision:<br/>spoke VNet + private endpoints<br/>+ AI services + Container Apps<br/>+ spoke→hub peering]
+    D --> E[You / hub team:<br/>create hub→spoke peering<br/>+ DNS zone links to spoke]
+    E --> F[Verify hello-world from<br/>jumpbox over Bastion]
+```
+
+The pre-flight script catches the most common hub-and-spoke mistakes (typos in `HUB_VNET_RESOURCE_ID`, subnets too small, CIDR overlap with hub, missing ACA delegation on BYO subnets) **before** ARM rejects the deployment 20 minutes in.
+
+## See also
+
+- [Source-repo hub-and-spoke runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md) — full walkthrough with test-hub Bicep, screenshots, and troubleshooting
+- [Migration to v2.0](migration-v2.md) — upgrade path from v1.x
+- [Parameterization](parameterization.md) — full parameter reference for the new BYO inputs
+- [v2.0.0 release notes](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0)

--- a/docs/bicep/migration-v2.md
+++ b/docs/bicep/migration-v2.md
@@ -1,0 +1,84 @@
+# Migration to v2.0
+
+This page summarizes the upgrade path from AI Landing Zone Bicep **v1.x** to **v2.0.0**. For the exhaustive breaking-change map, parameter-by-parameter migration tables, and gap-by-gap rationale, read the full guide at [docs/v2-migration.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) in the source repository.
+
+!!! info "First-time deployments"
+    You do **not** need this page if you are deploying for the first time. Go straight to [How to Deploy](how-to-deploy.md) or the [Hub-and-Spoke Topology](hub-and-spoke.md) walkthrough.
+
+## Why v2.0.0?
+
+v1.x assumed a **standalone** topology: the template provisions every networking and platform resource the AI workload needs inside a single subscription. That worked for green-field demos, but broke down for customers integrating the AI workload into an existing **Application Landing Zone** where the hub already provides:
+
+- Azure Firewall and a central NAT egress path
+- A Bastion host and shared jumpbox VMs
+- Centrally-managed Private DNS zones
+- A platform Log Analytics workspace and Application Insights
+
+v2.0.0 lets you bring any of those resources from the outside via an existing-resource-ID parameter — while keeping the ability to fall back to "create it for me" on a per-resource basis. Additional flexibility added in v2.0.0:
+
+- **Hybrid network access** — combine private endpoints with a public IP allow-list (the `allowedIpRanges` parameter) so a dev workstation can hit the data plane without routing the whole team through Bastion.
+- **Decoupled hub components** — independently deploy or BYO the jumpbox, Bastion, and NAT Gateway.
+- **Topology preset** — set the deployment shape once with `deploymentMode`, and the template derives a coherent default for every networking and identity flag.
+- **Pre-flight validation** — a PowerShell script runs as an `azd preprovision` hook and catches misconfigured BYO IDs, undersized subnets, CIDR overlaps, and parameter conflicts before they reach ARM.
+
+## Big-picture changes
+
+| Capability | v1.x | v2.0.0 |
+|---|---|---|
+| Topology preset | Implicit | New `deploymentMode` (`standalone` \| `ailz-integrated`) |
+| IP allow-list for PaaS data planes | Not supported | New `allowedIpRanges` parameter, applied to 7 services |
+| Jumpbox / Bastion / NAT Gateway | One coarse `deployVM` flag | Three independent flags + BYO resource IDs |
+| Observability | Always creates LAW + App Insights | Can reuse existing LAW and App Insights (cross-subscription supported) |
+| Private DNS zones | Always created by the spoke | Can BYO **per zone** (15 overrides) plus `dnsZoneLinkSuffix` for shared zones |
+| Hub egress | Implicit Azure Firewall in same RG | Can route to an **external** firewall / NVA via next-hop IP |
+| Hub peering | Manual post-deploy | Spoke→hub created by `main.bicep` |
+| Container app port | Always `8080` | Per-app `target_port` honored (still defaults to `8080`) |
+| Pre-flight validation | None | New `scripts/Invoke-PreflightChecks.ps1` runs automatically before `azd provision` |
+
+Internally, every v2.0.0 parameter has either a sensible default that reproduces v1.x behavior, or a `null`/empty default that means **"don't override"**. Apart from the explicit `deployVM` → `deployJumpbox` / `deployBastion` / `deployNatGateway` split, the v1.x mental model still works.
+
+## Breaking changes that need operator action
+
+### `deployVM` is split into three flags
+
+`deployVM` is removed. Replace each `deployVM=true` with the three independent flags:
+
+```bash
+# Before
+azd env set DEPLOY_VM true
+
+# After (v2.0.0)
+azd env set DEPLOY_JUMPBOX      true
+azd env set DEPLOY_BASTION      true
+azd env set DEPLOY_NAT_GATEWAY  true
+```
+
+If you only want the jumpbox VM and not Bastion or the NAT Gateway, set only `DEPLOY_JUMPBOX=true`. The previous "all or nothing" semantics are gone.
+
+### `keyVaultResourceId` is replaced
+
+The flat `keyVaultResourceId` parameter is replaced by a structured BYO Key Vault reference. See the [full migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md#3-3-key-vault-byo-parameter-renamed) for the exact replacement and parameter file diff.
+
+### Default container app port
+
+The default Container Apps ingress port is still `8080`, but each entry in `containerAppsList` can now set an explicit `target_port`. If you previously relied on the implicit `80` from a custom image, set `target_port: 80` explicitly.
+
+### Pre-flight hook now runs by default
+
+`azd provision` now invokes `scripts/Invoke-PreflightChecks.ps1` via the `azd preprovision` hook. Set `PREFLIGHT_SKIP=true` in your shell to bypass it.
+
+## Quick upgrade checklist
+
+1. **Read the source guide** — [docs/v2-migration.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) for the full parameter map.
+2. **Bump the submodule** if you consume the template as `infra/` in a downstream accelerator — pin to `v2.0.0`.
+3. **Replace `deployVM`** with the three new flags in your `azd env` and/or `main.parameters.json`.
+4. **Run the pre-flight script** manually first: `pwsh -File scripts/Invoke-PreflightChecks.ps1 -AzdEnv <your-env>`.
+5. **Re-run `azd provision`** in a non-production environment to catch anything the pre-flight script didn't.
+6. **Adopt the new features** — `deploymentMode`, `allowedIpRanges`, BYO LAW / App Insights / DNS zones — opportunistically.
+
+## See also
+
+- [Source-repo migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) — exhaustive parameter map, exit codes, pre-flight matrix
+- [Source-repo standalone runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-standalone.md)
+- [Source-repo hub-and-spoke runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md)
+- [v2.0.0 release notes](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0)

--- a/docs/bicep/overview.md
+++ b/docs/bicep/overview.md
@@ -8,14 +8,15 @@ The Azure AI Landing Zone is an enterprise-scale, production-ready reference arc
 
 ## Deployment modes
 
-The template supports two deployment modes that you can choose based on your security requirements:
+The template supports three deployment topologies that you choose with the `deploymentMode` parameter (introduced in **v2.0.0**). Each topology is a curated set of defaults — every individual flag remains overridable.
 
-| Mode | Network isolation | Jumpbox VM | Use case |
-|---|---|---|---|
-| **Basic** | No | Optional | Quick demos and development environments |
-| **Zero Trust** | Yes | Yes (via Bastion) | Production workloads requiring full network isolation |
+| Mode | `deploymentMode` value | Network isolation | Jumpbox VM | Hub integration | Use case |
+|---|---|---|---|---|---|
+| **Standalone** | `standalone` (default) | Optional (`networkIsolation=true`) | Optional | None | Self-contained sandbox: a single spoke that contains its own Bastion, NAT Gateway, and (optionally) Azure Firewall |
+| **Hub-and-Spoke (test)** | `standalone` + `hubIntegration.hubVnetResourceId` set | Yes | Yes | Spoke peers to a hub you own | Same template, plus a peering to a hub VNet that hosts the shared Bastion/Firewall |
+| **AI LZ Integrated** | `ailz-integrated` | Yes (enforced) | Off by default | Required (via existing hub) | The spoke participates in an Azure Landing Zone: it reuses hub services (Firewall, Bastion, Private DNS, Log Analytics) instead of provisioning its own |
 
-Both modes are deployed using the [Azure Developer CLI (`azd`)](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd). See [How to Deploy](how-to-deploy.md) for step-by-step instructions.
+All three topologies are deployed using the [Azure Developer CLI (`azd`)](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd). See [How to Deploy](how-to-deploy.md) for step-by-step instructions and the [Hub-and-Spoke Topology](hub-and-spoke.md) runbook for the full hub + spoke walkthrough.
 
 ## What gets deployed
 
@@ -46,8 +47,22 @@ Every service can be individually toggled on or off via deploy parameters. See [
 
 The deployment configures role-based access control (RBAC) for service-to-service communication using managed identities. See [Permissions](permissions.md) for the complete list of role assignments.
 
+## What's new in v2.0.0
+
+**v2.0.0** (May 2026) extends the template with composability features for enterprises integrating the AI Landing Zone into an existing Azure Landing Zone. The major themes:
+
+- **Bring your own platform services** — the spoke can now consume an existing Log Analytics workspace, Application Insights, hub VNet, Private DNS zones, route table, and NAT Gateway / Bastion / jumpbox VM. Cross-subscription scenarios are supported.
+- **Hybrid network access** — the new `allowedIpRanges` parameter combines private endpoints with a public IP allow-list across Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and Container Registry.
+- **Topology preset** — pick `standalone` or `ailz-integrated` once with `deploymentMode`; the template derives a coherent default for every networking and identity flag.
+- **Decoupled jumpbox / Bastion / NAT Gateway** — each is now independently controllable; the old `deployVM` umbrella is removed.
+- **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically before `azd provision` and catches subnet sizing / CIDR overlap / parameter conflicts before they reach ARM.
+
+If you are upgrading from v1.x, read the [Migration to v2.0](migration-v2.md) guide before re-deploying.
+
 ## Next steps
 
 - [How to Deploy](how-to-deploy.md) — Prerequisites and deployment instructions
+- [Hub-and-Spoke Topology](hub-and-spoke.md) — Step-by-step walkthrough for ALZ-integrated deployments (**new in v2.0**)
+- [Migration to v2.0](migration-v2.md) — Breaking-change map and upgrade guide (**new in v2.0**)
 - [Parameterization](parameterization.md) — Full parameter reference
 - [Permissions](permissions.md) — Role assignments provisioned by the template

--- a/docs/bicep/parameterization.md
+++ b/docs/bicep/parameterization.md
@@ -31,7 +31,9 @@ azd env set NETWORK_ISOLATION true
 
 | Parameter | Default | Env variable | Description |
 |---|---|---|---|
-| `networkIsolation` | `false` | `NETWORK_ISOLATION` | Enable Zero Trust network isolation (private endpoints, VNet, Bastion, Jumpbox VM) |
+| `deploymentMode` | `standalone` | `DEPLOYMENT_MODE` | Topology preset (**v2.0.0+**): `standalone` (self-contained spoke) or `ailz-integrated` (peer to an existing hub VNet, reuse hub services) |
+| `networkIsolation` | `false` | `NETWORK_ISOLATION` | Enable Zero Trust network isolation (private endpoints, VNet) |
+| `allowedIpRanges` | `[]` | `ALLOWED_IP_RANGES` | IPv4 / CIDR allow-list (**v2.0.0+**) applied to Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and Container Registry data planes when `networkIsolation=true` |
 | `useZoneRedundancy` | `false` | — | Enable zone redundancy for supported services |
 | `useCMK` | `false` | — | Enable customer-managed keys for encryption |
 | `greenFieldDeployment` | `true` | — | Green-field deployment (creates all resources from scratch) |
@@ -54,12 +56,17 @@ Each toggle controls whether a specific service is provisioned. Set to `true` to
 | `deployMcp` | `true` | MCP (Model Context Protocol) server |
 | `deployGroundingWithBing` | `false` | Bing Grounding service |
 | `deployKeyVault` | `true` | Azure Key Vault |
-| `deployVmKeyVault` | — | `DEPLOY_VM_KEY_VAULT` | Separate Key Vault for VM secrets |
+| `deployVmKeyVault` | — | Separate Key Vault for VM secrets (`DEPLOY_VM_KEY_VAULT`) |
 | `deployLogAnalytics` | `true` | Log Analytics workspace |
 | `deploySearchService` | `true` | Azure AI Search service |
 | `deployStorageAccount` | `true` | Azure Storage account |
-| `deployVM` | `true` | Jumpbox Virtual Machine (used with network isolation) |
+| `deployJumpbox` | `null` (inherits from preset) | Jumpbox VM (**v2.0.0+** — replaces the v1.x `deployVM` flag) |
+| `deployBastion` | `null` (inherits from preset) | Azure Bastion host (**v2.0.0+** — independent of jumpbox) |
+| `deployNatGateway` | `null` (inherits from preset) | NAT Gateway for outbound traffic (**v2.0.0+** — independent of jumpbox) |
 | `deploySoftware` | `true` | Pre-install development tools on the Jumpbox VM |
+
+!!! warning "Breaking change in v2.0.0"
+    The v1.x umbrella flag `deployVM` is **removed**. Use the three independent flags `deployJumpbox` / `deployBastion` / `deployNatGateway` instead. See the [Migration to v2.0](migration-v2.md) guide.
 
 ## Resource name overrides
 
@@ -99,6 +106,40 @@ Use these parameters to reuse existing resources instead of creating new ones.
 | `aiSearchResourceId` | `null` | Resource ID of an existing AI Search service |
 | `aiFoundryStorageAccountResourceId` | `null` | Resource ID of an existing Storage account for AI Foundry |
 | `aiFoundryCosmosDBAccountResourceId` | `null` | Resource ID of an existing Cosmos DB account for AI Foundry |
+
+### v2.0.0 — Bring-your-own platform services
+
+These parameters were added in v2.0.0 to support the [hub-and-spoke topology](hub-and-spoke.md). Set any value to a resource ID to **reuse** that platform resource (cross-RG and cross-subscription supported); leave empty to let the template create it.
+
+| Parameter | Env variable | Description |
+|---|---|---|
+| `existingPlatformServices.logAnalyticsWorkspaceResourceId` | `EXISTING_LOG_ANALYTICS_WORKSPACE_ID` | Reuse a Log Analytics workspace from the hub for diagnostics + App Insights linkage |
+| `existingPlatformServices.applicationInsightsResourceId` | `EXISTING_APPLICATION_INSIGHTS_ID` | Reuse an existing Application Insights instance |
+| `existingPlatformServices.keyVaultResourceId` | `EXISTING_KEY_VAULT_ID` | Reuse a hub-managed Key Vault for shared secrets |
+| `existingBastionResourceId` | `EXISTING_BASTION_RESOURCE_ID` | Hub Bastion host that already has line-of-sight to the spoke jumpbox via peering |
+| `existingNatGatewayResourceId` | `EXISTING_NAT_GATEWAY_RESOURCE_ID` | Hub-owned NAT Gateway to associate with spoke subnets |
+| `existingJumpboxResourceId` | `EXISTING_JUMPBOX_RESOURCE_ID` | Reference to a hub-managed jumpbox VM (informational; used by docs and post-provisioning scripts) |
+| `existingPrivateDnsZones.*` | per-zone | 15 per-namespace overrides (blob, file, queue, table, vault, search, openai, cosmos-documents, redis, container apps, ACR, AMPLS, etc.). See the [source migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md#3-4-private-dns-zones) for the complete list and behavior |
+
+## Hub integration (v2.0.0)
+
+For `deploymentMode=ailz-integrated` or hybrid hub-and-spoke deployments.
+
+| Parameter | Env variable | Description |
+|---|---|---|
+| `hubIntegration.hubVnetResourceId` | `HUB_VNET_RESOURCE_ID` | Resource ID of the hub VNet to peer with. When set, the template creates a spoke→hub peering automatically. |
+| `hubIntegration.createHubPeering` | `CREATE_HUB_PEERING` | Whether the template should create the spoke→hub peering (default `true` when `hubVnetResourceId` is set) |
+| `hubIntegration.egressNextHopIp` | `EGRESS_NEXT_HOP_IP` | Private IP of the hub Azure Firewall / NVA. When set, the spoke UDR for `0.0.0.0/0` points here instead of a local firewall. |
+| `hubIntegration.existingRouteTableResourceId` | `EXISTING_ROUTE_TABLE_RESOURCE_ID` | BYO route table for the spoke workload subnets. Bypasses the auto-generated UDR. |
+| `hubIntegration.peeringAllowGatewayTransit` | — | Allow gateway transit on the spoke side of the peering |
+| `hubIntegration.peeringUseRemoteGateways` | — | Use remote gateways from the hub |
+
+## DNS zone link suffix (v2.0.0)
+
+| Parameter | Default | Env variable | Description |
+|---|---|---|---|
+| `dnsZoneLinkSuffix` | `''` | `DNS_ZONE_LINK_SUFFIX` | Suffix appended to VNet-link names when reusing shared Private DNS zones across multiple spokes, so links don't collide on name |
+| `linkExistingPrivateDnsZonesToSpoke` | `true` | — | When reusing BYO DNS zones, also create a link from each zone to the spoke VNet (needed when peering doesn't propagate DNS) |
 
 ## Networking
 

--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -1,5 +1,16 @@
 # What's New
 
+## 18th May 2026
+- **AI Landing Zones Bicep v2.0.0 released.** Adds hub-and-spoke composability and granular reuse of platform resources for Application Landing Zone (ALZ) integrated topologies. Highlights:
+    - **Topology preset** — new `deploymentMode` parameter (`standalone` / `ailz-integrated`)
+    - **IP allow-lists** — new `allowedIpRanges` parameter for "Zero Trust + named developer IPs" hybrid scenarios, applied uniformly to 7 PaaS services
+    - **Decoupled jumpbox / Bastion / NAT Gateway** — split from the old monolithic `deployVM` flag, each independently controllable, each with a BYO `existingResourceId` variant
+    - **Observability reuse** — bring your own Log Analytics workspace and Application Insights, including cross-subscription scenarios
+    - **Granular BYO Private DNS** — 15 per-zone override parameters, plus `dnsZoneLinkSuffix` for multi-spoke shared-zone topologies
+    - **Hub integration** — new spoke→hub VNet peering (created by `main.bicep`) and external-egress UDR via hub firewall/NVA
+    - **Pre-flight validation** — new `scripts/Invoke-PreflightChecks.ps1` runs as an `azd preprovision` hook to catch parameter mistakes before they reach ARM
+    - See the [Migration to v2.0](bicep/migration-v2.md) guide and the [Hub-and-Spoke Topology](bicep/hub-and-spoke.md) runbook for full details. Release: [v2.0.0](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0).
+
 ## 17th November 2025
 - AI Landing Zones goes from preview to GA
 - AI Landing Zones [Terraform guide](https://github.com/Azure/AI-Landing-Zones/blob/main/terraform/readme.md) published

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ nav:
   - Bicep Implementation:
       - "Overview": bicep/overview.md
       - "How to Deploy": bicep/how-to-deploy.md
+      - "Hub-and-Spoke Topology": bicep/hub-and-spoke.md
+      - "Migration to v2.0": bicep/migration-v2.md
       - "Permissions": bicep/permissions.md
       - "Parameterization": bicep/parameterization.md
   - Terraform Implementation: terraform/index.md


### PR DESCRIPTION
Updates the AI Landing Zones mkdocs site to cover the **v2.0.0** release of the Bicep template ([Azure/bicep-ptn-aiml-landing-zone v2.0.0](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0)).

## Changes

**Updated pages**

- docs/whatisnew.md — v2.0.0 highlight entry summarizing the seven major themes (`deploymentMode`, `allowedIpRanges`, decoupled jumpbox/Bastion/NAT Gateway, BYO observability, granular BYO DNS, hub integration, pre-flight script)
- docs/bicep/overview.md — deployment-modes table updated for the three topologies (Standalone / Hub-and-Spoke / AI LZ Integrated); new `What's new in v2.0.0` section
- docs/bicep/how-to-deploy.md — PowerShell 7+ added to prerequisites for the pre-flight hook; new `AI Landing Zone Integrated Deployment` section with the minimum env-var set
- docs/bicep/parameterization.md — all v2.0.0 parameters documented (`deploymentMode`, `allowedIpRanges`, `deployJumpbox/Bastion/NatGateway`, `hubIntegration.*`, `existingPlatformServices.*`, `existingPrivateDnsZones.*`, `dnsZoneLinkSuffix`); explicit breaking-change callout for the `deployVM` removal

**New pages**

- docs/bicep/migration-v2.md — concise v1.x → v2.0.0 upgrade guide, linking to the exhaustive source-repo guide for the deep dive
- docs/bicep/hub-and-spoke.md — topology overview with the spoke-creates-vs-consumes matrix and a Mermaid deployment-flow diagram

**Nav**

- `mkdocs.yml` — two new entries added under `Bicep Implementation`

## Validation

`mkdocs build --strict` runs clean locally — only the pre-existing INFO warnings about `AI-Landing-Zones-Design-Checklist.md` and `AI-Landing-Zones-Whats-New.md` (orphan pages from an earlier change, not touched here).