### PR TITLE
docs(bicep): soften v2 framing + add v2.0.1 hotfix entry

### DIFF
--- a/docs/bicep/how-to-deploy.md
+++ b/docs/bicep/how-to-deploy.md
@@ -13,7 +13,7 @@ Choose your preferred deployment mode based on project requirements and environm
 
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
-- [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) — required by the pre-flight validation hook (v2.0.0+)
+- [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell) — required by the pre-flight validation hook (v2+)
 - [Git](https://git-scm.com/downloads)
 
 !!! note
@@ -21,7 +21,7 @@ Choose your preferred deployment mode based on project requirements and environm
 
 ## Basic Deployment
 
-Quick setup for demos and development environments without network isolation. This is the **standalone** topology (the default in v2.0.0).
+Quick setup for demos and development environments without network isolation. This is the **standalone** topology (the default in v2).
 
 **1. Initialize the project**
 
@@ -137,6 +137,6 @@ azd provision
     The [Hub-and-Spoke Topology](hub-and-spoke.md) page documents this scenario end-to-end, including a minimal test hub Bicep template, IP planning, peering setup, and verifying connectivity through the hub Bastion.
 
 ## Next steps
-- [Migration to v2.0](migration-v2.md) — Upgrade guide for users coming from v1.x
+- [Migration to v2](migration-v2.md) — Upgrade guide for users coming from v1.x
 - [Parameterization](parameterization.md) — Customize your deployment
 - [Permissions](permissions.md) — Understand the role assignments

--- a/docs/bicep/hub-and-spoke.md
+++ b/docs/bicep/hub-and-spoke.md
@@ -1,6 +1,6 @@
 # Hub-and-Spoke Topology
 
-This page summarizes the **hub-and-spoke** deployment topology introduced in **v2.0.0**: the AI Landing Zone spoke peers to a hub VNet that hosts shared platform services (Azure Firewall, Bastion, Private DNS zones, Log Analytics workspace).
+This page summarizes the **hub-and-spoke** deployment topology introduced in **v2**: the AI Landing Zone spoke peers to a hub VNet that hosts shared platform services (Azure Firewall, Bastion, Private DNS zones, Log Analytics workspace).
 
 For the full end-to-end walkthrough — including the minimal test hub Bicep template, IP planning, peering setup, post-provisioning steps from the jumpbox, and the verification checklist — read the source runbook at [docs/runbook-hub-spoke.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md).
 
@@ -82,6 +82,6 @@ The pre-flight script catches the most common hub-and-spoke mistakes (typos in `
 ## See also
 
 - [Source-repo hub-and-spoke runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md) — full walkthrough with test-hub Bicep, screenshots, and troubleshooting
-- [Migration to v2.0](migration-v2.md) — upgrade path from v1.x
+- [Migration to v2](migration-v2.md) — upgrade path from v1.x
 - [Parameterization](parameterization.md) — full parameter reference for the new BYO inputs
-- [v2.0.0 release notes](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0)
+- [v2 release notes on GitHub](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases?q=v2&expanded=true)

--- a/docs/bicep/migration-v2.md
+++ b/docs/bicep/migration-v2.md
@@ -1,29 +1,29 @@
-# Migration to v2.0
+# Migration to v2
 
-This page summarizes the upgrade path from AI Landing Zone Bicep **v1.x** to **v2.0.0**. For the exhaustive breaking-change map, parameter-by-parameter migration tables, and gap-by-gap rationale, read the full guide at [docs/v2-migration.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) in the source repository.
+This page summarizes the upgrade path from AI Landing Zone Bicep **v1.x** to **v2**. For the complete parameter map and rationale, see the full guide at [docs/v2-migration.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) in the source repository.
 
 !!! info "First-time deployments"
     You do **not** need this page if you are deploying for the first time. Go straight to [How to Deploy](how-to-deploy.md) or the [Hub-and-Spoke Topology](hub-and-spoke.md) walkthrough.
 
-## Why v2.0.0?
+## Why v2?
 
-v1.x assumed a **standalone** topology: the template provisions every networking and platform resource the AI workload needs inside a single subscription. That worked for green-field demos, but broke down for customers integrating the AI workload into an existing **Application Landing Zone** where the hub already provides:
+v1.x assumed a **standalone** topology: the template provisions every networking and platform resource the AI workload needs inside a single subscription. That worked great for green-field demos, but it didn't fit customers integrating the AI workload into an existing **Application Landing Zone** where the hub already provides:
 
 - Azure Firewall and a central NAT egress path
 - A Bastion host and shared jumpbox VMs
 - Centrally-managed Private DNS zones
 - A platform Log Analytics workspace and Application Insights
 
-v2.0.0 lets you bring any of those resources from the outside via an existing-resource-ID parameter — while keeping the ability to fall back to "create it for me" on a per-resource basis. Additional flexibility added in v2.0.0:
+v2 lets you bring any of those resources from the outside via an existing-resource-ID parameter — while keeping the ability to fall back to "create it for me" on a per-resource basis. Additional features added in v2:
 
-- **Hybrid network access** — combine private endpoints with a public IP allow-list (the `allowedIpRanges` parameter) so a dev workstation can hit the data plane without routing the whole team through Bastion.
+- **Hybrid network access** — combine private endpoints with a public IP allow-list (`allowedIpRanges`) so a dev workstation can hit the data plane without routing the whole team through Bastion.
 - **Decoupled hub components** — independently deploy or BYO the jumpbox, Bastion, and NAT Gateway.
-- **Topology preset** — set the deployment shape once with `deploymentMode`, and the template derives a coherent default for every networking and identity flag.
+- **Topology preset** — set the deployment shape once with `deploymentMode` and the template picks coherent defaults for every networking and identity flag.
 - **Pre-flight validation** — a PowerShell script runs as an `azd preprovision` hook and catches misconfigured BYO IDs, undersized subnets, CIDR overlaps, and parameter conflicts before they reach ARM.
 
-## Big-picture changes
+## What changed at a glance
 
-| Capability | v1.x | v2.0.0 |
+| Capability | v1.x | v2 |
 |---|---|---|
 | Topology preset | Implicit | New `deploymentMode` (`standalone` \| `ailz-integrated`) |
 | IP allow-list for PaaS data planes | Not supported | New `allowedIpRanges` parameter, applied to 7 services |
@@ -33,11 +33,11 @@ v2.0.0 lets you bring any of those resources from the outside via an existing-re
 | Hub egress | Implicit Azure Firewall in same RG | Can route to an **external** firewall / NVA via next-hop IP |
 | Hub peering | Manual post-deploy | Spoke→hub created by `main.bicep` |
 | Container app port | Always `8080` | Per-app `target_port` honored (still defaults to `8080`) |
-| Pre-flight validation | None | New `scripts/Invoke-PreflightChecks.ps1` runs automatically before `azd provision` |
+| Pre-flight validation | None | `scripts/Invoke-PreflightChecks.ps1` runs automatically before `azd provision` |
 
-Internally, every v2.0.0 parameter has either a sensible default that reproduces v1.x behavior, or a `null`/empty default that means **"don't override"**. Apart from the explicit `deployVM` → `deployJumpbox` / `deployBastion` / `deployNatGateway` split, the v1.x mental model still works.
+Every v2 parameter has either a sensible default that reproduces v1.x behavior, or a `null`/empty default that means **"don't override"**. Apart from the explicit `deployVM` → `deployJumpbox` / `deployBastion` / `deployNatGateway` split, the v1.x mental model still works.
 
-## Breaking changes that need operator action
+## Things that need attention when upgrading
 
 ### `deployVM` is split into three flags
 
@@ -47,13 +47,13 @@ Internally, every v2.0.0 parameter has either a sensible default that reproduces
 # Before
 azd env set DEPLOY_VM true
 
-# After (v2.0.0)
+# After (v2)
 azd env set DEPLOY_JUMPBOX      true
 azd env set DEPLOY_BASTION      true
 azd env set DEPLOY_NAT_GATEWAY  true
 ```
 
-If you only want the jumpbox VM and not Bastion or the NAT Gateway, set only `DEPLOY_JUMPBOX=true`. The previous "all or nothing" semantics are gone.
+If you only want the jumpbox VM and not Bastion or the NAT Gateway, set only `DEPLOY_JUMPBOX=true`. The previous all-or-nothing semantics are gone.
 
 ### `keyVaultResourceId` is replaced
 
@@ -70,15 +70,15 @@ The default Container Apps ingress port is still `8080`, but each entry in `cont
 ## Quick upgrade checklist
 
 1. **Read the source guide** — [docs/v2-migration.md](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) for the full parameter map.
-2. **Bump the submodule** if you consume the template as `infra/` in a downstream accelerator — pin to `v2.0.0`.
+2. **Bump the submodule** if you consume the template as `infra/` in a downstream accelerator — pin to the latest v2 tag.
 3. **Replace `deployVM`** with the three new flags in your `azd env` and/or `main.parameters.json`.
 4. **Run the pre-flight script** manually first: `pwsh -File scripts/Invoke-PreflightChecks.ps1 -AzdEnv <your-env>`.
 5. **Re-run `azd provision`** in a non-production environment to catch anything the pre-flight script didn't.
-6. **Adopt the new features** — `deploymentMode`, `allowedIpRanges`, BYO LAW / App Insights / DNS zones — opportunistically.
+6. **Adopt the new features** — `deploymentMode`, `allowedIpRanges`, BYO LAW / App Insights / DNS zones — at your own pace.
 
 ## See also
 
 - [Source-repo migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md) — exhaustive parameter map, exit codes, pre-flight matrix
 - [Source-repo standalone runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-standalone.md)
 - [Source-repo hub-and-spoke runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md)
-- [v2.0.0 release notes](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0)
+- [v2 release notes on GitHub](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases?q=v2&expanded=true)

--- a/docs/bicep/overview.md
+++ b/docs/bicep/overview.md
@@ -8,7 +8,7 @@ The Azure AI Landing Zone is an enterprise-scale, production-ready reference arc
 
 ## Deployment modes
 
-The template supports three deployment topologies that you choose with the `deploymentMode` parameter (introduced in **v2.0.0**). Each topology is a curated set of defaults — every individual flag remains overridable.
+The template supports three deployment topologies. You pick one with the `deploymentMode` parameter — each topology is a curated set of defaults, and every individual flag remains overridable.
 
 | Mode | `deploymentMode` value | Network isolation | Jumpbox VM | Hub integration | Use case |
 |---|---|---|---|---|---|
@@ -47,22 +47,28 @@ Every service can be individually toggled on or off via deploy parameters. See [
 
 The deployment configures role-based access control (RBAC) for service-to-service communication using managed identities. See [Permissions](permissions.md) for the complete list of role assignments.
 
-## What's new in v2.0.0
+## What's new in v2
 
-**v2.0.0** (May 2026) extends the template with composability features for enterprises integrating the AI Landing Zone into an existing Azure Landing Zone. The major themes:
+The **v2** line adds two things that matter most for everyday use:
 
-- **Bring your own platform services** — the spoke can now consume an existing Log Analytics workspace, Application Insights, hub VNet, Private DNS zones, route table, and NAT Gateway / Bastion / jumpbox VM. Cross-subscription scenarios are supported.
-- **Hybrid network access** — the new `allowedIpRanges` parameter combines private endpoints with a public IP allow-list across Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and Container Registry.
-- **Topology preset** — pick `standalone` or `ailz-integrated` once with `deploymentMode`; the template derives a coherent default for every networking and identity flag.
-- **Decoupled jumpbox / Bastion / NAT Gateway** — each is now independently controllable; the old `deployVM` umbrella is removed.
-- **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically before `azd provision` and catches subnet sizing / CIDR overlap / parameter conflicts before they reach ARM.
+1. **A topology switch** — set `deploymentMode` to one of:
+    - **`standalone`** — the AI Landing Zone provisions everything it needs (VNet, private endpoints, Bastion, jumpbox, NAT Gateway, observability). Best for sandboxes, evaluations, and teams without a corporate hub.
+    - **`ailz-integrated`** — the AI Landing Zone deploys only the **spoke** (VNet + private endpoints + AI services) and peers into a hub VNet you already operate, reusing the hub's Firewall, Bastion, Private DNS zones, and Log Analytics workspace. Best for production inside an existing Azure Landing Zone.
+2. **Granular reuse of existing resources** — every platform service can be brought from the outside via an `existing*ResourceId` parameter (cross-subscription IDs are accepted): Log Analytics, Application Insights, Private DNS zones (per zone, 15 available), hub VNet, jumpbox, Bastion, NAT Gateway, route table.
 
-If you are upgrading from v1.x, read the [Migration to v2.0](migration-v2.md) guide before re-deploying.
+A handful of other quality-of-life additions:
+
+- **`allowedIpRanges`** — let named CIDRs reach the data plane of Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and App Configuration without disabling private endpoints. Use this when developers need to query the workload from their laptops without routing through Bastion.
+- **Decoupled hub components** — `deployJumpbox`, `deployBastion`, and `deployNatGateway` are now independent flags.
+- **Hub integration helpers** — `hubIntegration.hubVnetResourceId` creates the spoke→hub peering for you; `hubIntegration.egressNextHopIp` routes spoke egress through your hub firewall / NVA.
+- **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically as an `azd preprovision` hook and catches the usual mistakes (CIDR overlap, undersized subnets, missing BYO resource IDs, conflicting flags) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
+
+If you are upgrading from v1.x, read the [Migration to v2](migration-v2.md) guide before re-deploying.
 
 ## Next steps
 
 - [How to Deploy](how-to-deploy.md) — Prerequisites and deployment instructions
-- [Hub-and-Spoke Topology](hub-and-spoke.md) — Step-by-step walkthrough for ALZ-integrated deployments (**new in v2.0**)
-- [Migration to v2.0](migration-v2.md) — Breaking-change map and upgrade guide (**new in v2.0**)
+- [Hub-and-Spoke Topology](hub-and-spoke.md) — Step-by-step walkthrough for ALZ-integrated deployments
+- [Migration to v2](migration-v2.md) — Upgrade guide for users coming from v1.x
 - [Parameterization](parameterization.md) — Full parameter reference
 - [Permissions](permissions.md) — Role assignments provisioned by the template

--- a/docs/bicep/parameterization.md
+++ b/docs/bicep/parameterization.md
@@ -31,9 +31,9 @@ azd env set NETWORK_ISOLATION true
 
 | Parameter | Default | Env variable | Description |
 |---|---|---|---|
-| `deploymentMode` | `standalone` | `DEPLOYMENT_MODE` | Topology preset (**v2.0.0+**): `standalone` (self-contained spoke) or `ailz-integrated` (peer to an existing hub VNet, reuse hub services) |
+| `deploymentMode` | `standalone` | `DEPLOYMENT_MODE` | Topology preset (**v2+**): `standalone` (self-contained spoke) or `ailz-integrated` (peer to an existing hub VNet, reuse hub services) |
 | `networkIsolation` | `false` | `NETWORK_ISOLATION` | Enable Zero Trust network isolation (private endpoints, VNet) |
-| `allowedIpRanges` | `[]` | `ALLOWED_IP_RANGES` | IPv4 / CIDR allow-list (**v2.0.0+**) applied to Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and Container Registry data planes when `networkIsolation=true` |
+| `allowedIpRanges` | `[]` | `ALLOWED_IP_RANGES` | IPv4 / CIDR allow-list (**v2+**) applied to Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and Container Registry data planes when `networkIsolation=true` |
 | `useZoneRedundancy` | `false` | — | Enable zone redundancy for supported services |
 | `useCMK` | `false` | — | Enable customer-managed keys for encryption |
 | `greenFieldDeployment` | `true` | — | Green-field deployment (creates all resources from scratch) |
@@ -60,13 +60,13 @@ Each toggle controls whether a specific service is provisioned. Set to `true` to
 | `deployLogAnalytics` | `true` | Log Analytics workspace |
 | `deploySearchService` | `true` | Azure AI Search service |
 | `deployStorageAccount` | `true` | Azure Storage account |
-| `deployJumpbox` | `null` (inherits from preset) | Jumpbox VM (**v2.0.0+** — replaces the v1.x `deployVM` flag) |
-| `deployBastion` | `null` (inherits from preset) | Azure Bastion host (**v2.0.0+** — independent of jumpbox) |
-| `deployNatGateway` | `null` (inherits from preset) | NAT Gateway for outbound traffic (**v2.0.0+** — independent of jumpbox) |
+| `deployJumpbox` | `null` (inherits from preset) | Jumpbox VM (**v2+** — replaces the v1.x `deployVM` flag) |
+| `deployBastion` | `null` (inherits from preset) | Azure Bastion host (**v2+** — independent of jumpbox) |
+| `deployNatGateway` | `null` (inherits from preset) | NAT Gateway for outbound traffic (**v2+** — independent of jumpbox) |
 | `deploySoftware` | `true` | Pre-install development tools on the Jumpbox VM |
 
-!!! warning "Breaking change in v2.0.0"
-    The v1.x umbrella flag `deployVM` is **removed**. Use the three independent flags `deployJumpbox` / `deployBastion` / `deployNatGateway` instead. See the [Migration to v2.0](migration-v2.md) guide.
+!!! note "Changed in v2"
+    The v1.x umbrella flag `deployVM` is **removed**. Use the three independent flags `deployJumpbox` / `deployBastion` / `deployNatGateway` instead. See the [Migration to v2](migration-v2.md) guide.
 
 ## Resource name overrides
 
@@ -107,9 +107,9 @@ Use these parameters to reuse existing resources instead of creating new ones.
 | `aiFoundryStorageAccountResourceId` | `null` | Resource ID of an existing Storage account for AI Foundry |
 | `aiFoundryCosmosDBAccountResourceId` | `null` | Resource ID of an existing Cosmos DB account for AI Foundry |
 
-### v2.0.0 — Bring-your-own platform services
+### v2 — Bring-your-own platform services
 
-These parameters were added in v2.0.0 to support the [hub-and-spoke topology](hub-and-spoke.md). Set any value to a resource ID to **reuse** that platform resource (cross-RG and cross-subscription supported); leave empty to let the template create it.
+These parameters were added in v2 to support the [hub-and-spoke topology](hub-and-spoke.md). Set any value to a resource ID to **reuse** that platform resource (cross-RG and cross-subscription supported); leave empty to let the template create it.
 
 | Parameter | Env variable | Description |
 |---|---|---|
@@ -121,7 +121,7 @@ These parameters were added in v2.0.0 to support the [hub-and-spoke topology](hu
 | `existingJumpboxResourceId` | `EXISTING_JUMPBOX_RESOURCE_ID` | Reference to a hub-managed jumpbox VM (informational; used by docs and post-provisioning scripts) |
 | `existingPrivateDnsZones.*` | per-zone | 15 per-namespace overrides (blob, file, queue, table, vault, search, openai, cosmos-documents, redis, container apps, ACR, AMPLS, etc.). See the [source migration guide](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/v2-migration.md#3-4-private-dns-zones) for the complete list and behavior |
 
-## Hub integration (v2.0.0)
+## Hub integration (v2)
 
 For `deploymentMode=ailz-integrated` or hybrid hub-and-spoke deployments.
 
@@ -134,7 +134,7 @@ For `deploymentMode=ailz-integrated` or hybrid hub-and-spoke deployments.
 | `hubIntegration.peeringAllowGatewayTransit` | — | Allow gateway transit on the spoke side of the peering |
 | `hubIntegration.peeringUseRemoteGateways` | — | Use remote gateways from the hub |
 
-## DNS zone link suffix (v2.0.0)
+## DNS zone link suffix (v2)
 
 | Parameter | Default | Env variable | Description |
 |---|---|---|---|

--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -1,15 +1,18 @@
 # What's New
 
+## 19th May 2026
+- **AI Landing Zones Bicep v2.0.1 released.** Hotfix for a v2.0.0 regression in the AI Foundry account private-endpoint emission that caused `azd provision` to fail with `InvalidTemplate: 'The resource 'Microsoft.Resources/deployments/module.account.pe.<name>' is not defined in the template'` during template validation. Single-line fix; no behavior change for any topology. Release: [v2.0.1](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.1).
+
 ## 18th May 2026
-- **AI Landing Zones Bicep v2.0.0 released.** Adds hub-and-spoke composability and granular reuse of platform resources for Application Landing Zone (ALZ) integrated topologies. Highlights:
-    - **Topology preset** — new `deploymentMode` parameter (`standalone` / `ailz-integrated`)
+- **AI Landing Zones Bicep v2 released.** Adds hub-and-spoke composability and granular reuse of platform resources for Application Landing Zone (ALZ) integrated topologies. Highlights:
+    - **Topology preset** — new `deploymentMode` parameter (`standalone` / `ailz-integrated`) picks the deployment shape in one place
     - **IP allow-lists** — new `allowedIpRanges` parameter for "Zero Trust + named developer IPs" hybrid scenarios, applied uniformly to 7 PaaS services
-    - **Decoupled jumpbox / Bastion / NAT Gateway** — split from the old monolithic `deployVM` flag, each independently controllable, each with a BYO `existingResourceId` variant
+    - **Decoupled jumpbox / Bastion / NAT Gateway** — each is now an independent flag, each with a BYO `existingResourceId` variant
     - **Observability reuse** — bring your own Log Analytics workspace and Application Insights, including cross-subscription scenarios
     - **Granular BYO Private DNS** — 15 per-zone override parameters, plus `dnsZoneLinkSuffix` for multi-spoke shared-zone topologies
     - **Hub integration** — new spoke→hub VNet peering (created by `main.bicep`) and external-egress UDR via hub firewall/NVA
-    - **Pre-flight validation** — new `scripts/Invoke-PreflightChecks.ps1` runs as an `azd preprovision` hook to catch parameter mistakes before they reach ARM
-    - See the [Migration to v2.0](bicep/migration-v2.md) guide and the [Hub-and-Spoke Topology](bicep/hub-and-spoke.md) runbook for full details. Release: [v2.0.0](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0).
+    - **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs as an `azd preprovision` hook and catches parameter mistakes before they reach ARM
+    - See the [Migration to v2](bicep/migration-v2.md) guide and the [Hub-and-Spoke Topology](bicep/hub-and-spoke.md) runbook for full details. Release: [v2.0.0](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.0).
 
 ## 17th November 2025
 - AI Landing Zones goes from preview to GA

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
       - "Overview": bicep/overview.md
       - "How to Deploy": bicep/how-to-deploy.md
       - "Hub-and-Spoke Topology": bicep/hub-and-spoke.md
-      - "Migration to v2.0": bicep/migration-v2.md
+      - "Migration to v2": bicep/migration-v2.md
       - "Permissions": bicep/permissions.md
       - "Parameterization": bicep/parameterization.md
   - Terraform Implementation: terraform/index.md


### PR DESCRIPTION
Documentation-only cleanup of the v2 framing across the Bicep section of the mkdocs site, mirroring the same cleanup just landed in the source repository ([Azure/bicep-ptn-aiml-landing-zone#61](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/61)).

## Motivation

The previous wording on the Bicep pages leaned on phrasing like "v2.0.0", "breaking change", and "introduced in v2.0.0". This makes the site:

1. **Out of date the moment a patch ships** — `v2.0.0+` is wrong as soon as v2.0.1 is the latest release.
2. **More alarming than it needs to be** — the v1→v2 transition is real but the user-facing surface should be calm and task-focused.

This PR rewords for clarity and version-agnostic accuracy, while keeping every link to the source-repo guides where the exhaustive detail lives.

## What changes

**whatisnew.md**

- New top entry for v2.0.1 (hotfix for the AI Foundry account private-endpoint emission).
- v2.0.0 entry rephrased as "Bicep v2 released" — the bullet list is unchanged in substance.

**bicep/overview.md**

- `What's new in v2.0.0` -> `What's new in v2` with a user-task-focused structure (topology switch + BYO matrix + quality-of-life features).
- "introduced in v2.0.0" qualifier removed from the deployment modes table.

**bicep/migration-v2.md**

- Title becomes `Migration to v2`.
- References the v2 line rather than pinning to v2.0.0.
- Section heading `Breaking changes that need operator action` -> `Things that need attention when upgrading`.
- Submodule pin guidance now says "pin to the latest v2 tag".

**bicep/hub-and-spoke.md / how-to-deploy.md / parameterization.md**

- Minor wording sweeps replacing `v2.0.0+` with `v2+`, `Breaking change in v2.0.0` callout downgraded to `Changed in v2`.

**mkdocs.yml**

- Nav entry `Migration to v2.0` -> `Migration to v2`.

## What does **not** change

- No technical content removed.
- No code changes.

## Validation

`mkdocs build --strict` runs clean locally; only the pre-existing INFO warnings about orphan pages (not touched here).