### PR TITLE
docs(whatisnew): add v2.0.2 Bicep hotfix entry

### DIFF
--- a/docs/whatisnew.md
+++ b/docs/whatisnew.md
@@ -1,6 +1,7 @@
 # What's New
 
 ## 19th May 2026
+- **AI Landing Zones Bicep v2.0.2 released.** Hotfix for a v2.0.0 regression that caused `azd provision` to fail mid-deployment with `InvalidTemplate: 'databaseAccount_privateEndpoints[0]' / 'keyVault_privateEndpoints[0]' ... 'reference' is not valid: all function arguments should be string literals.` whenever `networkIsolation=false` was combined with the default `deployAiFoundry=true`. The fix gates the AI Foundry private-endpoint subnet on `_networkIsolation`, mirroring an existing sibling pattern in the same file. No behavior change for the `networkIsolation=true` (Zero Trust) topology. Release: [v2.0.2](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.2).
 - **AI Landing Zones Bicep v2.0.1 released.** Hotfix for a v2.0.0 regression in the AI Foundry account private-endpoint emission that caused `azd provision` to fail with `InvalidTemplate: 'The resource 'Microsoft.Resources/deployments/module.account.pe.<name>' is not defined in the template'` during template validation. Single-line fix; no behavior change for any topology. Release: [v2.0.1](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.1).
 
 ## 18th May 2026


### PR DESCRIPTION
Surfaces the [v2.0.2](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases/tag/v2.0.2) hotfix for the Bicep landing zone on the `What's New` page. The fix gates the AI Foundry-bundled Private Endpoint subnet on `_networkIsolation`, resolving an ARM template-validation failure that aborted `azd provision` mid-deployment whenever `networkIsolation=false` was combined with the default `deployAiFoundry=true`. Tracking issue: [#63](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/63).