### PR TITLE
docs(css): stop wrapping parameter / env-var identifiers mid-word in reference tables

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -11,3 +11,19 @@
   font-size: 0.85rem;
   line-height: 1.3;
 }
+
+/* Keep parameter / env-var identifiers in reference tables on a single line.
+   Material for MkDocs applies `word-break: break-word` to typeset tables,
+   which causes long camelCase names (e.g. `networkIsolation`,
+   `useZoneRedundancy`, `NETWORK_ISOLATION`) to wrap mid-word inside narrow
+   columns. We disable that for inline <code> elements inside tables — the
+   Material `.md-typeset__table` wrapper already provides horizontal scroll
+   when a row gets too wide, which is a much nicer fallback than breaking
+   identifiers mid-word. */
+.md-typeset table:not([class]) td code,
+.md-typeset table:not([class]) th code {
+  word-break: keep-all;
+  overflow-wrap: normal;
+  white-space: nowrap;
+}
+


### PR DESCRIPTION
On the live mkdocs site, long camelCase identifiers like `networkIsolation`, `useZoneRedundancy`, and `NETWORK_ISOLATION` are wrapping mid-word in the Bicep Parameterization page's narrow `Parameter` and `Env variable` columns. The break happens at e.g. `networkIsolatio` / `n` on the next line and `useZoneRedundan` / `cy` — readable but ugly.

### Root cause

Material for MkDocs applies `word-break: break-word` (a.k.a. `overflow-wrap: anywhere`) to typeset tables, so long unbreakable tokens get sliced at the column edge instead of overflowing.

### Fix

Single CSS override scoped to inline `<code>` inside typeset tables:

```css
.md-typeset table:not([class]) td code,
.md-typeset table:not([class]) th code {
  word-break: keep-all;
  overflow-wrap: normal;
  white-space: nowrap;
}
```

Identifiers now stay on one line. When a row gets too wide, the `.md-typeset__table` wrapper that Material already injects provides a horizontal scrollbar — a much nicer fallback than slicing the name in half.

### Validation

- `mkdocs build --strict` — passes locally (only the pre-existing INFO about orphan `AI-Landing-Zones-Design-Checklist.md` and `AI-Landing-Zones-Whats-New.md` pages, unrelated).
- Compiled `site/stylesheets/extra.css` contains the new rule.
- Scope is intentionally tight: only `<code>` *inside* table cells. Inline `<code>` in body prose is untouched.

No other docs files modified.
