### PR TITLE
Clarify retired Bicep docs redirect

### DIFF
--- a/docs/bicep/migration-v2.md
+++ b/docs/bicep/migration-v2.md
@@ -10,4 +10,4 @@ hide:
   window.location.replace("../how-to-deploy/");
 </script>
 
-This page moved to [How to Deploy](how-to-deploy.md).
+This page is no longer part of the Bicep documentation flow. Continue with [How to Deploy](how-to-deploy.md).


### PR DESCRIPTION
Updates the retired /bicep/migration-v2/ page so it remains available as a lightweight redirect to the Bicep deployment guide, without showing the old Migration to v2 content.