### PR TITLE
Add Public Ingress App Gateway runbook

### DIFF
--- a/docs/bicep/how-to-deploy.md
+++ b/docs/bicep/how-to-deploy.md
@@ -21,7 +21,7 @@ Choose your preferred deployment mode based on project requirements and environm
 
 ## Basic Deployment
 
-Quick setup for demos and development environments without network isolation. This is the **standalone** topology (the default in v2).
+Quick setup for demos and development environments without network isolation. This is the **standalone** topology.
 
 **1. Initialize the project**
 
@@ -97,6 +97,10 @@ After a Zero Trust deployment, use the Jumpbox VM to access services inside the 
    - In the Azure Portal, go to your VM resource → **Connect** → **Bastion**
    - Enter the credentials you set in step 1
 
+### Optional public endpoint
+
+If a private Container App must be reachable through a controlled public endpoint, use [Public Ingress with Application Gateway](public-ingress.md). The template first provisions an inert Application Gateway skeleton, then you complete the hostname, certificate, DNS, and allowed-source configuration.
+
 ## AI Landing Zone Integrated Deployment
 
 For deployments that **plug into an existing Azure Landing Zone** — i.e. the spoke peers to a corporate hub that already provides Bastion, Firewall, Private DNS zones, and Log Analytics.
@@ -137,5 +141,6 @@ azd provision
     The [Hub-and-Spoke Topology](hub-and-spoke.md) page documents this scenario end-to-end, including a minimal test hub Bicep template, IP planning, peering setup, and verifying connectivity through the hub Bastion.
 
 ## Next steps
+- [Public Ingress with Application Gateway](public-ingress.md) — Publish a private Container App through Application Gateway WAF v2
 - [Parameterization](parameterization.md) — Customize your deployment
 - [Permissions](permissions.md) — Understand the role assignments

--- a/docs/bicep/hub-and-spoke.md
+++ b/docs/bicep/hub-and-spoke.md
@@ -82,5 +82,6 @@ The pre-flight script catches the most common hub-and-spoke mistakes (typos in `
 ## See also
 
 - [Source-repo hub-and-spoke runbook](https://github.com/Azure/bicep-ptn-aiml-landing-zone/blob/main/docs/runbook-hub-spoke.md) — full walkthrough with test-hub Bicep, screenshots, and troubleshooting
+- [Public Ingress with Application Gateway](public-ingress.md) — publish a private Container App through Application Gateway WAF v2
 - [Parameterization](parameterization.md) — full parameter reference for BYO inputs
 - [Release notes on GitHub](https://github.com/Azure/bicep-ptn-aiml-landing-zone/releases)

--- a/docs/bicep/overview.md
+++ b/docs/bicep/overview.md
@@ -47,9 +47,9 @@ Every service can be individually toggled on or off via deploy parameters. See [
 
 The deployment configures role-based access control (RBAC) for service-to-service communication using managed identities. See [Permissions](permissions.md) for the complete list of role assignments.
 
-## What's new in v2
+## Highlights
 
-The **v2** line adds two things that matter most for everyday use:
+The Bicep implementation supports two deployment shapes that matter most for everyday use:
 
 1. **A topology switch** — set `deploymentMode` to one of:
     - **`standalone`** — the AI Landing Zone provisions everything it needs (VNet, private endpoints, Bastion, jumpbox, NAT Gateway, observability). Best for sandboxes, evaluations, and teams without a corporate hub.
@@ -67,5 +67,6 @@ A handful of other quality-of-life additions:
 
 - [How to Deploy](how-to-deploy.md) — Prerequisites and deployment instructions
 - [Hub-and-Spoke Topology](hub-and-spoke.md) — Step-by-step walkthrough for ALZ-integrated deployments
+- [Public Ingress with Application Gateway](public-ingress.md) — Publish a private Container App through Application Gateway WAF v2
 - [Parameterization](parameterization.md) — Full parameter reference
 - [Permissions](permissions.md) — Role assignments provisioned by the template

--- a/docs/bicep/parameterization.md
+++ b/docs/bicep/parameterization.md
@@ -37,6 +37,7 @@ azd env set NETWORK_ISOLATION true
 | `useZoneRedundancy` | `false` | — | Enable zone redundancy for supported services |
 | `useCMK` | `false` | — | Enable customer-managed keys for encryption |
 | `greenFieldDeployment` | `true` | — | Green-field deployment (creates all resources from scratch) |
+| `publicIngress` | `{ enabled: false }` | — | Optional Application Gateway WAF v2 public endpoint for a private Container App. See [Public Ingress with Application Gateway](public-ingress.md). |
 
 ## Deploy toggles
 
@@ -112,7 +113,7 @@ Use these to compose hub-and-spoke and Application Landing Zone (ALZ) topologies
 | `aiFoundryCosmosDBAccountResourceId` | `AI_FOUNDRY_COSMOS_DB_ACCOUNT_RESOURCE_ID` | Reuse an existing Cosmos DB account as the AI Foundry Cosmos backing. |
 | `keyVaultResourceId` | `KEY_VAULT_RESOURCE_ID` | Reuse an existing Key Vault for the workload (skips local vault creation). |
 
-### Observability (v2)
+### Observability
 
 | Parameter | Env variable | Description |
 |---|---|---|
@@ -128,7 +129,7 @@ Use these to compose hub-and-spoke and Application Landing Zone (ALZ) topologies
 | `hubIntegrationHubVnetResourceId` | `HUB_INTEGRATION_HUB_VNET_RESOURCE_ID` | Resource ID of the hub VNet to peer with. When set and `hubIntegrationCreateHubPeering=true`, the deployment creates the spoke→hub peering automatically (the reverse hub→spoke direction is the operator's responsibility — see `tests/scripts/Add-HubSpokePeering.ps1`). |
 | `hubIntegrationExistingRouteTableResourceId` | `HUB_INTEGRATION_EXISTING_ROUTE_TABLE_RESOURCE_ID` | Existing Route Table to attach to the spoke workload subnets. When set, the deployment skips local RT creation and assumes the RT is already configured with the correct default route. |
 
-### Hub jumpbox / Bastion / NAT (v2)
+### Hub jumpbox / Bastion / NAT
 
 When any of these is set, the matching `deploy*` flag defaults to `false`, so the spoke reuses the hub-managed component instead of deploying its own.
 
@@ -138,7 +139,7 @@ When any of these is set, the matching `deploy*` flag defaults to `false`, so th
 | `existingNatGatewayResourceId` | `EXISTING_NAT_GATEWAY_RESOURCE_ID` | Hub-managed NAT Gateway to associate with the spoke subnets for outbound egress. |
 | `existingJumpboxResourceId` | `EXISTING_JUMPBOX_RESOURCE_ID` | Reference to a hub-managed jumpbox VM. Informational — surfaced to runbooks and post-provision scripts. |
 
-### Private DNS zones (v2)
+### Private DNS zones
 
 All 15 zones used by the landing zone can be brought from a central platform subscription independently. When any of these is set, the local zone is **not** created. Pre-link the zone to the spoke VNet (or rely on hub→spoke peering + hub-side link) — automatic spoke linking is not performed. When `policyManagedPrivateDns=true`, no zone creation or linking happens regardless of these overrides.
 
@@ -160,7 +161,7 @@ All 15 zones used by the landing zone can be brought from a central platform sub
 | `existingPrivateDnsZoneAzureAutomationResourceId` | `privatelink.agentsvc.azure.automation.net` |
 | `existingPrivateDnsZoneAppInsightsResourceId` | `privatelink.applicationinsights.io` (consumed only when AMPLS is created locally) |
 
-## Hub integration (v2)
+## Hub integration
 
 For `deploymentMode=ailz-integrated` or hybrid hub-and-spoke deployments. See the [Hub-and-Spoke topology](hub-and-spoke.md) runbook for the full picture.
 
@@ -173,7 +174,7 @@ For `deploymentMode=ailz-integrated` or hybrid hub-and-spoke deployments. See th
 
 The BYO IDs that drive this section (`hubIntegrationHubVnetResourceId`, `hubIntegrationExistingRouteTableResourceId`) are listed in the [Networking BYO table above](#networking).
 
-## DNS zone link suffix (v2)
+## DNS zone link suffix
 
 | Parameter | Default | Env variable | Description |
 |---|---|---|---|

--- a/docs/bicep/public-ingress.md
+++ b/docs/bicep/public-ingress.md
@@ -1,0 +1,178 @@
+# Public Ingress with Application Gateway
+
+Network-isolated deployments keep Container Apps private by default. The Container Apps environment is internal-only and is normally reached from inside the virtual network, for example from the jumpbox.
+
+Use **Public Ingress** when one Container App needs a controlled public entry point. The Bicep template provisions Azure Application Gateway WAF v2 in front of the private Container Apps environment, without making the environment itself public.
+
+!!! warning "Cost and teardown"
+    Application Gateway WAF v2 and Standard Public IP incur hourly charges while deployed. Turning `publicIngress.enabled` back to `false` does not delete resources that were already created by an incremental ARM deployment. Use `azd down` for full teardown, or manually delete the gateway, Public IP, WAF policy, NSG, and gateway identity.
+
+## What gets created
+
+When `publicIngress.enabled=true`, and the deployment also has `networkIsolation=true`, `deployContainerEnv=true`, `deployContainerApps=true`, and at least one app in `containerAppsList`, the template creates:
+
+| Resource | Purpose |
+|---|---|
+| Application Gateway WAF v2 | Public HTTPS entry point for one Container App backend. |
+| Standard Public IP | Public address for the gateway. |
+| WAF policy | Managed WAF rules, using Prevention mode by default. |
+| User-assigned identity | Lets Application Gateway read the TLS certificate from Key Vault. |
+| NSG for `AppGatewaySubnet` | Keeps the gateway closed until source CIDRs are configured. |
+| Diagnostic settings | Sends gateway logs and metrics to Log Analytics. |
+
+The backend defaults to the first app in `containerAppsList`. Use `publicIngress.backendAppIndex` to point to a different app.
+
+## Operating states
+
+Public Ingress is intentionally a two-step workflow.
+
+| State | Configuration | Behavior |
+|---|---|---|
+| Skeleton mode | `enabled=true`, but `frontendHostName` or `sslCertSecretId` is empty | The gateway resources exist, but Internet traffic is not opened through the NSG. |
+| Live mode | `enabled=true`, `frontendHostName` and `sslCertSecretId` are set, and allowed source CIDRs are provided | HTTPS on 443 is enabled, HTTP redirects to HTTPS, and only configured CIDRs can reach the gateway. |
+
+This keeps the post-provision configuration in source control instead of relying on portal edits that can be overwritten later.
+
+## Step 1: enable the gateway skeleton
+
+In `main.parameters.json`, enable Public Ingress:
+
+```jsonc
+"publicIngress": {
+  "value": {
+    "enabled": true
+  }
+}
+```
+
+Provision the landing zone:
+
+```bash
+azd provision
+```
+
+After provisioning, capture the `PUBLIC_INGRESS_PUBLIC_IP` output. You can get it from the `azd provision` output or from the resource group deployment outputs in the Azure portal.
+
+## Step 2: prepare the hostname and certificate
+
+Choose the public hostname, for example:
+
+```text
+app.contoso.com
+```
+
+From the jumpbox, use the ACME client installed by the bootstrap script:
+
+```powershell
+C:\tools\win-acme\wacs.exe
+```
+
+Use a DNS-01 flow with your DNS provider, then import the certificate into the landing-zone Key Vault. The jumpbox managed identity has the Key Vault certificate permissions needed for this workflow.
+
+After import, copy the **versionless** Key Vault secret URI for the certificate:
+
+```text
+https://<key-vault-name>.vault.azure.net/secrets/<certificate-name>
+```
+
+Use the versionless URI, not a URI that includes a certificate version.
+
+## Step 3: point DNS at Application Gateway
+
+In your public DNS provider, create or update an A record:
+
+| Record | Value |
+|---|---|
+| `app.contoso.com` | `PUBLIC_INGRESS_PUBLIC_IP` |
+
+Wait for DNS propagation before validating the endpoint.
+
+## Step 4: switch to live mode
+
+Update `main.parameters.json` with the hostname, certificate secret URI, and source CIDRs that are allowed to reach the gateway:
+
+```jsonc
+"publicIngress": {
+  "value": {
+    "enabled": true,
+    "frontendHostName": "app.contoso.com",
+    "sslCertSecretId": "https://<key-vault-name>.vault.azure.net/secrets/<certificate-name>",
+    "allowedSourceAddressPrefixes": ["203.0.113.0/24"]
+  }
+}
+```
+
+Provision again:
+
+```bash
+azd provision
+```
+
+The template now configures the HTTPS listener, attaches the Key Vault certificate, redirects HTTP to HTTPS, and opens the NSG only for the configured source CIDRs.
+
+## Step 5: validate
+
+From an allowed source:
+
+```bash
+curl -v https://app.contoso.com/
+curl -v http://app.contoso.com/
+```
+
+Expected behavior:
+
+| Test | Expected result |
+|---|---|
+| `https://app.contoso.com/` | Returns the Container App response. |
+| `http://app.contoso.com/` | Redirects to HTTPS. |
+| Source outside `allowedSourceAddressPrefixes` | Cannot reach the gateway on 443. |
+
+## Parameter reference
+
+```bicep
+publicIngress: {
+  enabled: bool
+  backendAppIndex: int?
+  frontendHostName: string?
+  sslCertSecretId: string?
+  allowedSourceAddressPrefixes: string[]?
+  wafMode: ('Prevention' | 'Detection')?
+  wafCustomRules: object[]?
+  capacity: object?
+  sslPolicy: object?
+}
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Master switch for Public Ingress. |
+| `backendAppIndex` | `0` | Index into `containerAppsList` for the backend app. |
+| `frontendHostName` | Empty | Public hostname used by the HTTPS listener. Required for live mode. |
+| `sslCertSecretId` | Empty | Versionless Key Vault secret URI for the TLS certificate. Required for live mode. |
+| `allowedSourceAddressPrefixes` | `[]` | CIDRs allowed to reach HTTPS on 443. Empty keeps the gateway closed. |
+| `wafMode` | `Prevention` | WAF mode. |
+| `wafCustomRules` | `[]` | Optional custom WAF rules. |
+| `capacity` | `{ minCapacity: 0, maxCapacity: 2 }` | Application Gateway autoscale capacity. |
+| `sslPolicy` | `{}` | Optional Application Gateway SSL policy block. |
+
+## Useful outputs
+
+| Output | Description |
+|---|---|
+| `PUBLIC_INGRESS_ENABLED` | Whether Public Ingress was deployed. |
+| `PUBLIC_INGRESS_PUBLIC_IP` | Public IPv4 address for the gateway. |
+| `PUBLIC_INGRESS_GATEWAY_RESOURCE_ID` | Application Gateway resource ID. |
+| `PUBLIC_INGRESS_NSG_RESOURCE_ID` | NSG attached to `AppGatewaySubnet`. |
+| `PUBLIC_INGRESS_WAF_POLICY_RESOURCE_ID` | WAF policy resource ID. |
+| `PUBLIC_INGRESS_IDENTITY_PRINCIPAL_ID` | Gateway identity principal ID. Use this if an external Key Vault must grant certificate access. |
+| `PUBLIC_INGRESS_LIVE` | `true` when live mode is active. |
+
+## Teardown
+
+For full teardown:
+
+```bash
+azd down
+```
+
+If the rest of the landing zone must remain, delete the Public Ingress resources manually: Application Gateway, Public IP, WAF policy, NSG, and gateway user-assigned identity.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - "Overview": bicep/overview.md
       - "How to Deploy": bicep/how-to-deploy.md
       - "Hub-and-Spoke Topology": bicep/hub-and-spoke.md
+      - "Public Ingress (App Gateway)": bicep/public-ingress.md
       - "Permissions": bicep/permissions.md
       - "Parameterization": bicep/parameterization.md
   - Terraform Implementation: terraform/index.md


### PR DESCRIPTION
Adds a dedicated Bicep documentation page for Public Ingress with Application Gateway WAF v2, highlights it in the GitHub Pages navigation, and links it from Overview, How to Deploy, Hub-and-Spoke, and Parameterization.