### PR TITLE
Fix Portal Deploy to Azure branch targets

### DIFF
--- a/PortalDeploymentGuide.md
+++ b/PortalDeploymentGuide.md
@@ -6,7 +6,7 @@ The Portal-based AI Landing Zone deploys a secure, enterprise-ready AI/ML infras
 
 **Deploy to Azure:**
 
-[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fportal%2Fportal%2Ftemplate.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fportal%2Fportal%2Fform.json)
+[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fmain%2Fportal%2Ftemplate.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fmain%2Fportal%2Fform.json)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The table represents the various reference implementations of the AI Landing Zon
 | ----------- | ----------- |
 | Terraform | [Repo](https://aka.ms/ailz/terraform) |
 | Bicep | [Repo](https://aka.ms/ailz/bicep) |
-| Portal | [![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fportal%2Fportal%2Ftemplate.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fportal%2Fportal%2Fform.json) |
+| Portal | [![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fmain%2Fportal%2Ftemplate.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FAI-Landing-Zones%2Frefs%2Fheads%2Fmain%2Fportal%2Fform.json) |
 
 > **Note:** The previous Bicep implementation is still available in the [`legacy-bicep`](https://github.com/Azure/AI-Landing-Zones/tree/legacy-bicep) branch for users who need the legacy codebase.
 

--- a/portal/template.json
+++ b/portal/template.json
@@ -409,7 +409,7 @@
     "jumpVMConcat": "[concat('vm-', parameters('baseName'), '-jmp')]",
     "jumpVMName": "[if(greater(length(variables('jumpVMConcat')), 15), toLower(substring(variables('jumpVMConcat'), 0, 15)), toLower(variables('jumpVMConcat')))]",
 
-    "baseTemplateUri": "https://raw.githubusercontent.com/Azure/AI-Landing-Zones/refs/heads/portalbicepalignment/portal/",
+    "baseTemplateUri": "https://raw.githubusercontent.com/Azure/AI-Landing-Zones/refs/heads/main/portal/",
     "artifactsLocationSasToken": "",
     "networkSecurityGroupTemplateUri": "[uri(variables('baseTemplateUri'), concat('wrappers/avm.res.network.network-security-group.json', variables('artifactsLocationSasToken')))]",
     "virtualNetworkTemplateUri": "[uri(variables('baseTemplateUri'), concat('wrappers/avm.res.network.virtual-network.json', variables('artifactsLocationSasToken')))]",


### PR DESCRIPTION
## Summary

Updates the Portal **Deploy to Azure** links and linked-template base URI to load the merged portal deployment artifacts from `main` instead of older or staging branches.

## Problem

PR #128 merged the updated Portal deployment artifacts into `main`, but the Deploy to Azure buttons in `README.md` and `PortalDeploymentGuide.md` still loaded `portal/portal/template.json` and `portal/portal/form.json`. In addition, `portal/template.json` resolved linked wrapper templates from `portalbicepalignment`.

This meant customer-facing deployments could continue loading stale branch content after the Portal/Bicep alignment work had merged.

## Fix

- Point the Deploy to Azure links in `README.md` and `PortalDeploymentGuide.md` to `main/portal/template.json` and `main/portal/form.json`.
- Point `portal/template.json`'s `baseTemplateUri` to `main/portal/`.
- Leave Portal behavior, parameters, wrappers, and documentation structure unchanged.

## Validation

- Confirmed `portal/template.json` and `portal/form.json` parse successfully as JSON.
- Confirmed no stale `portal` or `portalbicepalignment` branch references remain in the three changed files.
- Confirmed all required `main` branch targets are present.
- Confirmed the diff is limited to 3 files with 3 insertions and 3 deletions.